### PR TITLE
Add sealedsecrets integration w/ charts

### DIFF
--- a/charts/fe-charts/templates/secret.yaml
+++ b/charts/fe-charts/templates/secret.yaml
@@ -1,4 +1,22 @@
 {{- if .Values.deployment.containers.env.secret.enabled }}
+
+{{- if .Values.secret.isSealedSecrets }}
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: {{ .Values.serviceName }}-secret
+  namespace: {{ .Release.Namespace }}
+spec:
+  encryptedData:
+    {{- if .Values.secret.data }}
+{{ toYaml .Values.secret.data | indent 4 }}
+    {{- end }}
+  template:
+    metadata:
+      name: {{ .Values.serviceName }}-secret
+      namespace: {{ .Release.Namespace }}
+
+{{- else }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,4 +27,7 @@ data:
   {{- if .Values.secret.data }}
 {{ toYaml .Values.secret.data | indent 2 }}
   {{- end }}
+
+{{- end }}
+
 {{- end }}

--- a/charts/fe-charts/values.yaml
+++ b/charts/fe-charts/values.yaml
@@ -74,4 +74,5 @@ configmap:
   data: {}
 
 secret:
+  isSealedSecrets: false
   data: {}


### PR DESCRIPTION
Add `SealedSecrets` integration w/ chart creation

Example of usage can be seen in this [values file](https://github.com/oyindonesia/k8s-manifests/pull/1444/files#diff-b7ace521cbf93b84de9ea21f0942029b686a6db59634a4e058afc8f2fcff9fe2R30)

Tested also w/ b2xportal's existing values and still works as expected
`helm template fe-charts/ -f ../../k8s-manifests/frontend/b2xportal/prod/values.yaml > /tmp/b2xportalnew.yml`