### PR TITLE
Add PodDisruptionBudget for all fe-chart releases

### DIFF
--- a/charts/fe-charts/Chart.yaml
+++ b/charts/fe-charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fe-charts
 description: A Helm chart for Oy Frontend App
 type: application
-version: 0.3.8
+version: 0.3.9
 appVersion: 1.0.0

--- a/charts/fe-charts/templates/pdb.yaml
+++ b/charts/fe-charts/templates/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.serviceName }}-pdb
+  namespace: {{ .Release.Namespace }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ .Values.serviceName }}

--- a/charts/fe-charts/templates/pdb.yaml
+++ b/charts/fe-charts/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.deployment.containers.env.pdb.enabled }}
+{{- if .Values.pdb.enabled }}
 
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/charts/fe-charts/templates/pdb.yaml
+++ b/charts/fe-charts/templates/pdb.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.deployment.containers.env.pdb.enabled }}
+
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -8,3 +10,5 @@ spec:
   selector:
     matchLabels:
       app: {{ .Values.serviceName }}
+
+{{- end }}

--- a/charts/fe-charts/values.yaml
+++ b/charts/fe-charts/values.yaml
@@ -65,6 +65,10 @@ hpa:
           type: AverageValue
           averageValue: 500Mi
 
+pdb:
+  enabled: false
+  minAvailable: 1
+
 service:
   type: ClusterIP
   port: 3000


### PR DESCRIPTION
Enable PodDisruptionBudget for all fe-chart releases.
Related with https://github.com/oyindonesia/k8s-manifests/pull/3152

## PR Description & Objective
<!-- Explain what this PR is trying to achieve, give links also to related documentations, slack conversations, other PRs-->
Enable PodDisruptionBudget for all fe-chart releases.
Related with https://github.com/oyindonesia/k8s-manifests/pull/3152

## Test render local
Dev (w/o PDB)
<img width="905" alt="image" src="https://github.com/oyindonesia/fe-charts/assets/38131950/7c543b85-3ce5-4267-b57c-555821e4b493">


Prod (w/ PDB)
<img width="1090" alt="image" src="https://github.com/oyindonesia/fe-charts/assets/38131950/3ba5919f-03ca-4b54-bb5d-599e53777028">

Note: k8s-manifest/frontend already use `kubeval --ignore-missing-schemas`, no additional change needed
<img width="881" alt="image" src="https://github.com/oyindonesia/fe-charts/assets/38131950/8caa2528-347a-47c8-a8c1-e630ac87fb9f">

## Affected Services / Instances
<!-- List out all instances along with their environments that will be affected by this PR's deployment after merging -->
- [x] fe-b2xmobile (dev prod)
- [x] fe-b2xportal  (dev prod)
- [x] fe-internalwpp (dev prod)
- [x] fe-paycheckout(dev prod)

## Deployment Plan
<!-- How are you going to deploy this PR after merging?, provide also additional steps if there's any -->
Merge this to main, create PR to gh-pages, then follow https://github.com/oyindonesia/k8s-manifests/pull/3152 via CCI