### PR TITLE
Add security contexts to FE chart template

### DIFF
--- a/charts/fe-charts/Chart.yaml
+++ b/charts/fe-charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fe-charts
 description: A Helm chart for Oy Frontend App
 type: application
-version: 0.3.10
+version: 0.3.11
 appVersion: 1.0.0

--- a/charts/fe-charts/templates/deployment.yaml
+++ b/charts/fe-charts/templates/deployment.yaml
@@ -42,6 +42,7 @@ spec:
         {{- end }}
       dnsPolicy: {{ .Values.deployment.dnsPolicy }}
       {{- end }}
+      serviceAccountName: {{ .Release.Name }}-serviceaccount
       containers: 
         - name: {{ .Values.serviceName }}
           image: {{ .Values.containerRegistry }}/{{ .Values.serviceName }}:{{ .Values.imageVersion }}
@@ -65,6 +66,12 @@ spec:
             periodSeconds: {{ .Values.deployment.containers.readiness.periodSeconds }}
             successThreshold: {{ .Values.deployment.containers.readiness.successThreshold }}
             failureThreshold: {{ .Values.deployment.containers.readiness.failureThreshold }}
+          {{- if .Values.deployment.containers.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.deployment.containers.securityContext.runAsUser }}
+            runAsNonRoot: {{ .Values.deployment.containers.securityContext.runAsNonRoot }}
+            readOnlyRootFilesystem: {{ .Values.deployment.containers.securityContext.readOnlyRootFilesystem }}
+          {{- end }}
           resources:
             limits:
               cpu: {{ .Values.deployment.containers.resources.limits.cpu }}

--- a/charts/fe-charts/templates/serviceaccount.yaml
+++ b/charts/fe-charts/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceaccount.create }}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-serviceaccount
+
+{{- end }}

--- a/charts/fe-charts/values.yaml
+++ b/charts/fe-charts/values.yaml
@@ -30,6 +30,10 @@ deployment:
       path: /ping
       initialDelaySeconds: 15
       periodSeconds: 10
+    securityContext:
+      runAsUser: 1000
+      runAsNonRoot: true
+      readOnlyRootFilesystem: true
     env:
       enabled: false
       configmap:
@@ -73,6 +77,9 @@ service:
   type: ClusterIP
   port: 3000
   targetPort: 3000
+
+serviceaccount:
+  create: false
 
 configmap:
   data: {}


### PR DESCRIPTION
## PR Description
Add security contexts to FE chart template. In order to comply with our kube-linter FE checks, we need:
- service account for each release
- read only filesystem
- run as non root

## Related PRs
- https://github.com/oyindonesia/k8s-manifests/pull/3542
- https://github.com/oyindonesia/infra_ansible/pull/807

## Testing
Tested using `helm lint`
![image](https://github.com/oyindonesia/fe-charts/assets/62831261/d56c8d7c-3ebc-4ab4-b2d1-c36fb19be397)
