### PR TITLE
Add volume mount for /tmp

### DIFF
--- a/charts/fe-charts/templates/deployment.yaml
+++ b/charts/fe-charts/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
             runAsNonRoot: {{ .Values.deployment.containers.securityContext.runAsNonRoot }}
             readOnlyRootFilesystem: {{ .Values.deployment.containers.securityContext.readOnlyRootFilesystem }}
           {{- end }}
+          volumeMounts:
+            - name: tmp-volume
+              mountPath: /tmp
           resources:
             limits:
               cpu: {{ .Values.deployment.containers.resources.limits.cpu }}
@@ -95,3 +98,6 @@ spec:
         {{- if .Values.deployment.additionalContainers }}
 {{ toYaml .Values.deployment.additionalContainers | indent 8 }}      
         {{- end }}
+      volumes:
+        - name: tmp-volume
+          emptyDir: {}


### PR DESCRIPTION
## PR Description
For containers with `readOnlyRootFilesystem`, yarn still needs to write cache so we need to mount an `emptyDir` volume.

## Testing
Via helm lint
![image](https://github.com/oyindonesia/fe-charts/assets/62831261/4a3bad36-aa9a-4178-9ef5-f574864f7658)
