### PR TITLE
feat: implement podAntiAffinity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/charts/fe-charts/Chart.yaml
+++ b/charts/fe-charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fe-charts
 description: A Helm chart for Oy Frontend App
 type: application
-version: 0.4.2
+version: 0.5.0
 appVersion: 1.0.0

--- a/charts/fe-charts/templates/deployment.yaml
+++ b/charts/fe-charts/templates/deployment.yaml
@@ -33,6 +33,18 @@ spec:
 {{ toYaml . | indent 8 }}
         {{- end }}
     spec:
+      {{- if and .Values.podAntiAffinity.enabled .Values.serviceName }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - {{ .Values.serviceName }}
+            topologyKey: "kubernetes.io/hostname"
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
       {{- if .Values.deployment.dnsConfig.enabled }}  
       dnsConfig:

--- a/charts/fe-charts/values.yaml
+++ b/charts/fe-charts/values.yaml
@@ -85,3 +85,6 @@ secret:
 
 serviceaccount:
   create: false
+
+podAntiAffinity:
+  enabled: false


### PR DESCRIPTION
## Description
Implement podAntiAffinity if .Values.podAntiAffinity.enabled and .Values.serviceName.
As this is a new feature, I prefer to not enable this by default for now. Feel free to enable by default in the future.

Note that I use `requiredDuringSchedulingIgnoredDuringExecution` instead of `preferredDuringSchedulingIgnoredDuringExecution`; this is consistent with javarepo.

Increment minor version as this is new feature.

## Test
Enabled, note the `spec.template.spec.affinity.podAntiAffinity`:
```
❯ pwd                                                                                                                           12:32:11
/Users/hafizh/Documents/fe-charts/charts/fe-charts
❯ helm template . -s templates/deployment.yaml -f ~/Documents/k8s-manifests/frontend/b2xportal/prod/values.yaml 
---
# Source: fe-charts/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: fe-b2xportal
  namespace: default
  annotations:
    prometheus.io/port: "9102"
    prometheus.io/scrape: "true"
spec:
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 0
    type: RollingUpdate
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: fe-b2xportal
  template:
    metadata:
      annotations:
        prometheus.io/port: "9102"
        prometheus.io/scrape: "true"
      labels:
        app: fe-b2xportal
    spec:
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchExpressions:
              - key: app
                operator: In
                values:
                - fe-b2xportal
            topologyKey: "kubernetes.io/hostname"
      terminationGracePeriodSeconds: 60  
      dnsConfig:
        nameservers:
        - 10.130.33.41
      dnsPolicy: None
      serviceAccountName: fe-b2xportal-serviceaccount
      containers: 
        - name: fe-b2xportal
          image: asia-southeast2-docker.pkg.dev/prod-pay/ferepo/fe-b2xportal:dinamic
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 2709
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /ping
              port: http
            initialDelaySeconds: 15
            periodSeconds: 15
            successThreshold: 
            failureThreshold: 
          readinessProbe:
            httpGet:
              path: /ping
              port: http
            initialDelaySeconds: 15
            periodSeconds: 10
            successThreshold: 
            failureThreshold: 
          securityContext:
            runAsUser: 1000
            runAsNonRoot: 
            readOnlyRootFilesystem: true
          volumeMounts:
            - name: tmp-volume
              mountPath: /tmp
          resources:
            limits:
              cpu: 250m
              memory: 500Mi
            requests:
              cpu: 250m
              memory: 500Mi  
          envFrom:  
          - secretRef:
              name: fe-b2xportal-secret
      volumes:
        - name: tmp-volume
          emptyDir: {}
```

Disabled, note the `spec.template.spec.affinity.podAntiAffinity`:
```
❯ pwd                                                                                                                           12:32:11
/Users/hafizh/Documents/fe-charts/charts/fe-charts
helm template . -s templates/deployment.yaml -f ~/Documents/k8s-manifests/frontend/b2xmobile/prod/values.yaml  
---
# Source: fe-charts/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: fe-b2xmobile
  namespace: default
  annotations:
    prometheus.io/port: "9102"
    prometheus.io/scrape: "true"
spec:
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 0
    type: RollingUpdate
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: fe-b2xmobile
  template:
    metadata:
      annotations:
        prometheus.io/port: "9102"
        prometheus.io/scrape: "true"
      labels:
        app: fe-b2xmobile
    spec:
      terminationGracePeriodSeconds: 60  
      dnsConfig:
        nameservers:
        - 10.130.33.41
      dnsPolicy: None
      serviceAccountName: fe-b2xmobile-serviceaccount
      containers: 
        - name: fe-b2xmobile
          image: asia-southeast2-docker.pkg.dev/prod-pay/ferepo/fe-b2xmobile:dinamic
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 3000
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /ping
              port: http
            initialDelaySeconds: 15
            periodSeconds: 15
            successThreshold: 
            failureThreshold: 
          readinessProbe:
            httpGet:
              path: /ping
              port: http
            initialDelaySeconds: 15
            periodSeconds: 10
            successThreshold: 
            failureThreshold: 
          securityContext:
            runAsUser: 1000
            runAsNonRoot: 
            readOnlyRootFilesystem: true
          volumeMounts:
            - name: tmp-volume
              mountPath: /tmp
          resources:
            limits:
              cpu: 250m
              memory: 500Mi
            requests:
              cpu: 250m
              memory: 500Mi  
          envFrom:  
          - secretRef:
              name: fe-b2xmobile-secret
      volumes:
        - name: tmp-volume
          emptyDir: {}
```