### PR TITLE
feat: add imagePullSecrets

### DIFF
--- a/charts/fe-charts/templates/deployment.yaml
+++ b/charts/fe-charts/templates/deployment.yaml
@@ -57,7 +57,13 @@ spec:
       {{- if .Values.serviceaccount.create}}
       serviceAccountName: {{ .Values.serviceName }}-serviceaccount
       {{- end }}
-      containers: 
+      {{- if .Values.deployment.imagePullSecrets }}
+      imagePullSecrets:
+        {{- with .Values.deployment.imagePullSecrets }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
         - name: {{ .Values.serviceName }}
           image: {{ .Values.containerRegistry }}/{{ .Values.serviceName }}:{{ .Values.imageVersion }}
           imagePullPolicy: {{ .Values.deployment.containers.imagePullPolicy | default "IfNotPresent" }}

--- a/charts/fe-charts/values.yaml
+++ b/charts/fe-charts/values.yaml
@@ -45,6 +45,8 @@ deployment:
       limits:
         cpu: "250m"
         memory: "500Mi"
+  imagePullSecrets: []
+
   #hostAliases provides Pod-level override of hostname resolution when DNS and other options are not applicable. This is optional, the value default to false
   hostAliases:
     enabled: false


### PR DESCRIPTION
Goal: introduce Deployment's `spec.template.spec.imagePullSecrets[]`

Default: empty list

Result:
<img width="1577" alt="image" src="https://github.com/user-attachments/assets/b1d1f7ed-c4ce-4b08-bcb4-38cc8573482b" />

left: render result from paycheckout's prod values.yaml without imagePullSecrets
```bash
cd fe-charts/charts/fe-charts
helm template . -f <omitted>/k8s-manifests/frontend/paycheckout/prod/values.yaml
```

right: render result from paycheckout's minipg/kpayk/prod values.yaml with imagePullSecrets
```bash
cd fe-charts/charts/fe-charts
helm template . -f <omitted>/k8s-manifests/frontend/paycheckout/minipg/kpayk/prod/values.yaml
```