### PR TITLE
feat: change default hpa spec to use memory utilization

### DIFF
--- a/charts/fe-charts/Chart.yaml
+++ b/charts/fe-charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fe-charts
 description: A Helm chart for Oy Frontend App
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: 1.0.0

--- a/charts/fe-charts/values.yaml
+++ b/charts/fe-charts/values.yaml
@@ -66,8 +66,8 @@ hpa:
       resource:
         name: memory
         target:
-          type: AverageValue
-          averageValue: 500Mi
+          type: Utilization
+          averageUtilization: 75
 
 pdb:
   enabled: false


### PR DESCRIPTION
Better to use utilization than static value, since we dont need to update hpa spec when deployment spec changed